### PR TITLE
fix: on shutting down, drop lagging work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quartz"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 authors = ["Alex Snaps <alex@wcgw.dev>"]
 license = "Apache-2.0"

--- a/src/threading/mod.rs
+++ b/src/threading/mod.rs
@@ -53,6 +53,9 @@ impl SchedulerThread {
           while !halted.load(Acquire) {
             if let Some(job) = store.next_job(DEFAULT_WAIT_NO_WORK) {
               workers.wait_for_worker();
+              if halted.load(Acquire) {
+                break;
+              }
               workers
                 .submit(job)
                 .expect("We should _always_ have a worker available!");


### PR DESCRIPTION
When we were asked to shutdown, drop pending jobs once worker become available.